### PR TITLE
Finshed grade command Needs Testing

### DIFF
--- a/csci_tool/commands/__init__.py
+++ b/csci_tool/commands/__init__.py
@@ -2,10 +2,12 @@ from .collect import CollectCommand
 from .create_repos import CreateReposCommand
 from .login import LoginCommand
 from .mutate import MutateCommand
+from .grade import GradeCommand
 
 subcommands = [
     CollectCommand(),
     CreateReposCommand(),
     LoginCommand(),
     MutateCommand(),
+    GradeCommand(),
 ]

--- a/csci_tool/commands/grade.py
+++ b/csci_tool/commands/grade.py
@@ -98,12 +98,12 @@ human grading'
                 list = grader.human_grade(student, source_dir)
                 os.chdir(cwd)
                 for i in list[1]:
-                    shell_output = subprocess.Popen('cat ' + i, shell=True, stdout=subprocess.PIPE, cwd=student_submission)
+                    shell_output = subprocess.Popen('subl ' + i, shell=True, stdout=subprocess.PIPE, cwd=student_submission)
                     output = shell_output.stdout.read()
                     output = output.decode("utf-8")
                     print (output)
                 score = input('score out of {}: '.format(list[0]))
-                writer.writerow([student.repo_name] + score)
+                writer.writerow([student.repo_name] + [score])
 
 
         # done grading, commit our changes

--- a/csci_tool/commands/grade.py
+++ b/csci_tool/commands/grade.py
@@ -1,11 +1,16 @@
 import argparse
 import logging
+import csv
+import subprocess
+import os
 from os import path
+
 
 from .base import BaseCommand
 from ..config import Config
 from ..grader import Grader
 from ..repo import Repo
+from ..student import Student
 
 
 logger = logging.getLogger(__name__)
@@ -17,7 +22,7 @@ class GradeCommand(BaseCommand):
 human grading'
 
     def populate_args(self):
-        self.add_argument('auto', help='run auto grading scripts',
+        self.add_argument('--auto', help='run auto grading scripts',
                           action='store_true')
         self.add_argument('assignment', help='assignment name')
         self.add_argument('students', help='students file', nargs='?',
@@ -27,20 +32,23 @@ human grading'
     def run(self, args):
         assignment = args.assignment
 
-        meta_repo = Repo.meta_rep()
+        meta_repo = Repo.meta_repo()
         meta_dir = meta_repo.working_tree_dir
+       	#is any of this needed 
         if args.students is None and not args.auto:
             # if we're running in human grader mode and didn't get a
             # students.txt then use the students.txt generated for the current
             # grader by their USC unix name
             my_name = Config.load_config().unix_name
+            #TODO This Path does not seem right
             default = path.join(meta_dir, 'submissions', assignment,
                                 'grade_' + my_name + '.txt')
             print('Loading students to grade for ' + my_name)
             with open(default, 'r') as students_file:
                 students = self.load_students(students_file)
         else:
-            students = self.load_students(args)
+        	#Looking at mutate.py it seems only this line is needed 
+            students = self.load_students(args.students)
 
         logger.info('Collecting from %d students', len(students))
 
@@ -49,22 +57,70 @@ human grading'
         # TODO(vmagro) does this also pull down submodules?
 
         # run auto grader or human grading script and write to grades.csv
-        for student in students:
-            grader = Grader.get_grader(assignment)
+        try:
+        	grader = Grader.get_grader(assignment)
+        except AttributeError:
+            l.error('grade.py doesn\'t seem to have a auto_grade or human_grade function')
+            return
+        except:
+            l.error('Failed to import grader "%s", are you sure it exists?',
+                    assignment)
+            return
+
+        # clone all the repos first
+        def clone(student):
+            try:
+                path = Repo.clone_student_repo(student)
+            except:
+                l.error('Failed to clone repo, does it exist and is your ' +
+                        'internet connection working?')
+                raise
+            return student, path
+        try:
+            repos = [clone(s) for s in students]
+        except:
+            l.error('Cloning one or more repos failed')
+            return
+
+
+        # source_dir is where the mutator files exist in the meta repo
+        source_dir = path.join(meta_dir, 'submissions', assignment)
+        
+        #set up grades.csv if it is not set up
+        os.chdir(source_dir)
+        print(source_dir)
+        if args.auto:
+            writer = csv.writer(open('grades.csv', 'a', newline=''), dialect='excel') 
+        else:
+            writer = csv.writer(open('grades.csv', 'a', newline=''), dialect='excel')                                        
+        # make the changes
+        for student, repo in repos:
             if args.auto:
                 logger.info('Auto-grading %s', student.unix_name)
+                repo_path = repo.git.rev_parse("--show-toplevel")
+                cwd = os.getcwd()
+                os.chdir(repo_path)
                 # run auto grader script and write out a line of CSV
-                score, max_score = grader.auto_grade
+                score, max_score = grader.auto_grade(student, source_dir)
+                os.chdir(cwd)
+                writer.writerow([student.repo_name] + [score])
+                #write to grades.csv
                 print(score, max_score)
             else:
                 # show the relevant files to a human
                 # wait for them to give a score, then write out a line of CSV
-                max_score = 10
+                list = grader.human_grade(student, source_dir)
+                for i in list:
+                    shell_output = subprocess.Popen('cat' + list[i], shell=True, stdout=subprocess.PIPE, cwd=repo_path)
+                    output = shell_output.stdout.read()
+                    output = output.decode("utf-8")
+                    print (output)
                 score = input('score out of {}: '.format(max_score))
-                return (score, max_score)
+                writer.writerow([student.repo_name] + [score])
+
 
         # done grading, commit our changes
-        meta_repo.index.add([path.join('submissions', assignment, 'grades.csv')])
+        meta_repo.index.add([path.join(meta_dir, 'submissions', assignment, 'grades.csv')])
         meta_repo.index.commit('Graded {} for {} students'
                                .format(assignment, len(students)))
         logger.info('Pushing changes to meta repo')

--- a/csci_tool/commands/mutate.py
+++ b/csci_tool/commands/mutate.py
@@ -60,9 +60,10 @@ class MutateCommand(BaseCommand):
         # source_dir is where the mutator files exist in the meta repo
         source_dir = path.join(meta_dir, mutation_name)
         # make the changes
-        for student, repo_path in repos:
+        for student, repo in repos:
             l.info('Mutating repo: %s', student.unix_name)
             cwd = os.getcwd()
+            repo_path = repo.git.rev_parse("--show-toplevel")
             os.chdir(repo_path)
             os.makedirs(mutation_name, exist_ok=True)
             os.chdir(mutation_name)
@@ -72,9 +73,9 @@ class MutateCommand(BaseCommand):
         # commit and push our changes
         for student, repo_path in repos:
             l.info('Committing repo: %s', student.unix_name)
-            repo = GitRepo(repo_path)
+            repo = repo_path
             repo.index.add('*')
             repo.index.commit('[course staff] ' + mutation_name)
             l.info('Pushing repo: %s', student.unix_name)
             repo.remote().push()
-            l.info('Pushed repo: %s', student.unx_name)
+            l.info('Pushed repo: %s', student.unix_name)

--- a/csci_tool/grader.py
+++ b/csci_tool/grader.py
@@ -30,9 +30,12 @@ class Grader():
                 student (Student)
                 source_dir (PathLike): directory where grade.py lives
             Returns:
-                tuple (int, int): (score, max_score)
+                tuple (list, int): (list_of_scores, max_score)
 
-        human_grade(student):
+        human_grade(student, source_dir):
+            Arguments:
+                student (Student)
+                source_dir (PathLike): directory where grade.py lives
             Returns:
                 list of str: files that should be shown to the grader
 

--- a/csci_tool/grader.py
+++ b/csci_tool/grader.py
@@ -37,6 +37,7 @@ class Grader():
                 student (Student)
                 source_dir (PathLike): directory where grade.py lives
             Returns:
+                tuple(max_score, list_of_str)
                 list of str: files that should be shown to the grader
 
         auto_grade and human_grade are run with cwd set to the corresponding

--- a/csci_tool/main.py
+++ b/csci_tool/main.py
@@ -6,10 +6,10 @@ import os
 
 # setup custom git ssh key if necessary
 # this must happen before importing any commands that use GitPython
-from .config import Config
-config = Config.load_config()
-if config.ssh_key is not None:
-    os.environ['GIT_SSH_COMMAND'] = 'ssh -i ' + config.ssh_key
+#from .config import Config
+#config = Config.load_config()
+#if config.ssh_key is not None:
+#    os.environ['GIT_SSH_COMMAND'] = 'ssh -i ' + config.ssh_key
 
 from .commands import subcommands  # noqa
 

--- a/students.txt
+++ b/students.txt
@@ -1,0 +1,1 @@
+picus@usc.edu picus3


### PR DESCRIPTION
So I think I finished up the grade section a couple of things I changed:
I added all the cloning code from mutate to grade.py and changed the way the students file was read in, wasn't working the previous way, but i might have screwed something up here. This I tested and seemed to work fine

The auto_grade function returns a tuple(list_of_scores, max_score)
This way we can return performance vs correctness score. It then writes these all to a grades.csv file stored in meta/submissions/<assingment> formatted: student repo name | score1 | score2 | score3| ect.

The human_grade functions will cat the list of returned files. I could not figure out how to use less from the python. I will look more into it, but currently it just prints out all the cat-ed files onto the terminal, and then prompts the grader for a score. The score is then saved in grades_human.csv stored in the same place and formatted: student repo name | score1
I looked into attempting to add it to the previous csv file, and tbh it looked like it would be way easier to just open the two files both up in excel and copy and paste them into main grades excel document. 

I made changes in __init.py__ to add the grade command

the changes I made in main.py and mutate.py were just to get the program to run. Not sure if you fixed them in your version. In mutate it looked kind of just like simple typos, and main was the previous ssh_key issue we talked about.

Let me know your thoughts! Also I could not seem to get the collect command to work. Not sure if that if I'm doing something wrong.
